### PR TITLE
Update apimversioned.ps1

### DIFF
--- a/apimversioned/apimversioned.ps1
+++ b/apimversioned/apimversioned.ps1
@@ -187,7 +187,7 @@ shared VNET
 				}		
 				else
 				{
-					$importurl="$($baseurl)/apis/$($newapi)?import=true&api-version=2017-03-01"
+					$importurl="$($baseurl)/apis/$($newapi)$($v)?import=true&api-version=2017-03-01"
 				}
 				$headers.Add("If-Match","*")		
 				#reapplying swagger


### PR DESCRIPTION
The API update flow for import swagger definition is done always over the original API version, instead of the new ones.