### PR TITLE
Set the version set display name so it doesn't default to the api id.

### DIFF
--- a/apimversioned/v3/apimversioned.ps1
+++ b/apimversioned/v3/apimversioned.ps1
@@ -189,7 +189,7 @@ shared VNET
 				#creating the api version set, the api and importing the swagger definition into it
 				$version="$($newapi)versionset"
 				$versionseturl="$($baseurl)/api-version-sets/$($version)?api-version=$($MicrosoftApiManagementAPIVersion)"
-				$json='{"id":"/api-version-sets/'+$($version)+'","name":"'+$($newapi)+'",'+$($scheme)+'}'
+				$json='{"id":"/api-version-sets/'+$($version)+'","name":"'+$($newapi)+'","displayName":"'+$($DisplayName)+'",'+$($scheme)+'}'
 				Write-Host "Creating version set using $($versionseturl) using $($json)"
 				Invoke-WebRequest -UseBasicParsing -Uri $versionseturl  -Body $json -ContentType "application/json" -Headers $headers -Method Put
 				$apiurl="$($baseurl)/apis/$($newapi)?api-version=$($MicrosoftApiManagementAPIVersion)"


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/rest/api/apimanagement/2019-01-01/apiversionset/createorupdate

`versionSetId` vs `name` vs `displayName`

The display name is what shows in the azure portal so we want this to be pretty and consistent with our unversioned apis.