### PR TITLE
Doesn't appear baseUrl was being set.

### DIFF
--- a/apimglobalpolicy/v1/apimglobalpolicy.ps1
+++ b/apimglobalpolicy/v1/apimglobalpolicy.ps1
@@ -85,6 +85,7 @@ shared VNET
 		{
 			try
 			{
+				$baseurl="$($Endpoint.Url)subscriptions/$($Endpoint.Data.SubscriptionId)/resourceGroups/$($rg)/providers/Microsoft.ApiManagement/service/$($portal)"
 				$policyapiurl=	"$($baseurl)/policies/policy?api-version=2018-06-01-preview"
 				$JsonPolicies = "{
 				  `"properties`": {					


### PR DESCRIPTION
Hi @stephaneey much appreciated if you could review and merge this one for us.

When trying to use the task `stephane-eyskens.apim.apimglobalpolicy.apimglobalpolicy@1` we get the error:

`##[error]Invalid URI: The hostname could not be parsed.`

![image](https://user-images.githubusercontent.com/10990813/74434723-45eb5180-4e63-11ea-9f99-87e05dbb90b7.png)

even though the variables `ConnectedServiceNameARM`, `ResourceGroupName` and `ApiPortalName` have been correctly set.

My guess is the missing baseUrl assignment is the issue, but I'm not sure the best way to test this change.