### PR TITLE
Fixed a bug related to creating a new revision

### DIFF
--- a/apimversioned/v4/apimversioned.ps1
+++ b/apimversioned/v4/apimversioned.ps1
@@ -292,7 +292,7 @@ shared VNET
 					Write-Host "Current revision is $($currentRevision)"
                     if($NewRevision -eq $true)
                     {						
-						$rev=$revisions.count+1
+						$rev=([int]$revisions[-1].value.apiRevision)+1;
 						Write-Host "New revision is $($rev)"						
 						$revJson='{"properties":{"sourceApiId":"'+$($baseurl)+'/apis/'+$($apiVersionIdentifier)+';rev='+$($currentRevision)+'","apiRevisionDescription":"'+$($apiRevisionDescription)+'"}}'
 						Write-Host "New revision body is $($revJson)"

--- a/apimversioned/v4/apimversioned.ps1
+++ b/apimversioned/v4/apimversioned.ps1
@@ -289,10 +289,12 @@ shared VNET
 							}
 						}
 					}
+					$revisions = $revisions.value | Sort-Object -Property "createdDateTime" -Descending  
+
 					Write-Host "Current revision is $($currentRevision)"
                     if($NewRevision -eq $true)
                     {						
-						$rev=([int]$revisions[-1].value.apiRevision)+1;
+						$rev=([int]$revisions[0].apiRevision)+1;
 						Write-Host "New revision is $($rev)"						
 						$revJson='{"properties":{"sourceApiId":"'+$($baseurl)+'/apis/'+$($apiVersionIdentifier)+';rev='+$($currentRevision)+'","apiRevisionDescription":"'+$($apiRevisionDescription)+'"}}'
 						Write-Host "New revision body is $($revJson)"

--- a/apimversioned/v4/task.json
+++ b/apimversioned/v4/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": "4",
     "Minor": "1",
-    "Patch": "1"
+    "Patch": "2"
   },
   "preview": "true",
   "minimumAgentVersion": "1.95.0",


### PR DESCRIPTION
If you delete at least one revision, current implementation will always release to existing revision.

Consideration:
apiRevision by documentation is a string and my code does not take that into consideration. It might be non-integer value