### PR TITLE
Allow publishing Original Version of a versioned API

### DIFF
--- a/apimversioned/v3/task.json
+++ b/apimversioned/v3/task.json
@@ -187,9 +187,9 @@
       "name": "version",
       "type": "string",
       "label": "API Version",
-      "required": true,
+      "required": false,
       "helpMarkDown": "API version",
-      "defaultValue": "v1"
+      "defaultValue": ""
     },
     {
       "name": "scheme",

--- a/apimversioned/v4/task.json
+++ b/apimversioned/v4/task.json
@@ -194,9 +194,9 @@
       "name": "version",
       "type": "string",
       "label": "API Version",
-      "required": true,
+      "required": false,
       "helpMarkDown": "API version",
-      "defaultValue": "v1"
+      "defaultValue": ""
     },
     {
       "name": "subscriptionRequired",


### PR DESCRIPTION
In Azure Portal, you can remove the version for the API, which defaults the backend management API call to pass an empty string for the version  value.  This results in the portal displaying "original version", and a version is not required to be specified.  This PR is to mimic that functionality (in v3, and v4), as a version is not required to be specified by APIM.