### PR TITLE
Allow the `API Management - Set or update an operation policy` task to consume operations from a previous task

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ is good to associate the release of your backends APIs with their corresponding 
 ships with an API Security Checker that helps validating that all endpoints of an API are well secured, this is of course only applicable to non-public APIs.
 # Release Notes
 ## v3.5.2
+* Added the possibility to use previously created / updated operations - Serge Aradj
+## v3.5.1
 * Addition of the subscription flag to non-versioned APIs - Sorin Pasa
 * Possibility to support non-commercial endpoint - Joey Eng
 ## v3.5.0

--- a/apim/v5/apim.ps1
+++ b/apim/v5/apim.ps1
@@ -294,6 +294,8 @@ shared VNET
 			Write-Host "Number of products created by a previous task(s): $($products.Length)"
 		}
 
+		Write-Host ("##vso[task.setvariable variable=NewUpdatedApi;]$newapi")
+
 		foreach ($product in $products)
 		{
 			if($product -ne $null -and $product -ne "")

--- a/apim/v5/task.json
+++ b/apim/v5/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": "5",
     "Minor": "0",
-    "Patch": "1"
+    "Patch": "2"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "API Management - Create/Update API $(message)",

--- a/apimoperationpolicies/v5/task.json
+++ b/apimoperationpolicies/v5/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": "5",
     "Minor": "0",
-    "Patch": "1"
+    "Patch": "2"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "API Management - Set or update an operation policy $(message)",
@@ -48,6 +48,12 @@
       }
     },
     {
+      "name": "UseApiCreatedByPreviousTask",
+      "type": "boolean",
+      "label": "Operation(s) created by previous task",
+      "helpMarkDown": "Make sure the task that creates/updates the api(s) is not disabled and that it is executed by the same agent."
+    },
+    {
       "name": "ApiName",
       "type": "pickList",
       "label": "API",
@@ -55,13 +61,8 @@
       "helpMarkDown": "The API you want to list operations",
       "properties": {
         "EditableOptions": "True"
-      }
-    },
-    {
-      "name": "UseApiCreatedByPreviousTask",
-      "type": "boolean",
-      "label": "Operation(s) created by previous task",
-      "helpMarkDown": "Make sure the task that creates/updates the api(s) is not disabled and that it is executed by the same agent."
+      },
+      "visibleRule": "UseApiCreatedByPreviousTask=false"
     },
     {
       "name": "OperationName",

--- a/apimoperationpolicies/v5/task.json
+++ b/apimoperationpolicies/v5/task.json
@@ -58,6 +58,12 @@
       }
     },
     {
+      "name": "UseApiCreatedByPreviousTask",
+      "type": "boolean",
+      "label": "Operation(s) created by previous task",
+      "helpMarkDown": "Make sure the task that creates/updates the api(s) is not disabled and that it is executed by the same agent."
+    },
+    {
       "name": "OperationName",
       "type": "pickList",
       "label": "Operation",
@@ -65,7 +71,8 @@
       "helpMarkDown": "The operation you want to set or create policy",
       "properties": {
         "EditableOptions": "True"
-      }
+      },
+      "visibleRule": "UseApiCreatedByPreviousTask=false"
     },
     {
       "name": "CurrentRevision",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "apim",
   "name": "API Management Suite",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "publisher": "stephane-eyskens",
   "tags": [
     "API",


### PR DESCRIPTION
As described in issue #122, the goal of this PR is to allow an mass policy update on all operations from an API previously created/updated by a previous `API Management - Create or Update API` task.

Tested and validated on my devops environment (manually uploaded, and used alongside the unmodified `API Management - Create or update product` from your extension)