### PR TITLE
Set format of uploaded policy to rawXml

### DIFF
--- a/apim/v5/apim.ps1
+++ b/apim/v5/apim.ps1
@@ -321,7 +321,8 @@ shared VNET
 			{
 				$policyapiurl=	"$($baseurl)/apis/$($newapi)/policies/policy?api-version=$($MicrosoftApiManagementAPIVersion)"
 				$JsonPolicies = "{
-				  `"properties`": {					
+				  `"properties`": {
+				        `"format`":`"rawxml`",  
 					`"policyContent`":`""+$PolicyContent+"`"
 					}
 				}"


### PR DESCRIPTION
1. This allow to use non only valid xml as content of a policy, but also allow to use c# code inside. 
2. This format is already set at apimversioned.ps1